### PR TITLE
fix: wrong filename

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     # To build from source instead of using pre-built image, uncomment these lines:
     build:
       context: .
-      dockerfile: dockerfile
+      dockerfile: Dockerfile
     container_name: gofile-dl
     ports:
       - "2355:2355"


### PR DESCRIPTION
Fixed the letter case of the Dockerfile in docker-compose. (It didn't work in podman-compose without this fix.)