### PR TITLE
chore(renovate): run daily at 2am UTC

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -8,7 +8,7 @@ on:
   schedule:
     # The "*" (#42, asterisk) character has special semantics in YAML, so this
     # string has to be quoted.
-    - cron: "0 9 * * 1-5"
+    - cron: "0 2 * * *"
   workflow_dispatch:
     inputs:
       dryRun:


### PR DESCRIPTION
Standardizes the Renovate workflow schedule to a single daily run at 02:00 UTC (was weekdays 9am UTC), per fleet-wide scheduling change.

---
_Generated by [Claude Code](https://claude.ai/code/session_017anq3d4L4uQEZugiFoHgZY)_