### PR TITLE
ci: enable Renovate lock-file maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -11,6 +11,11 @@
   "platformAutomerge": true,
   "automergeStrategy": "squash",
 
+  "lockFileMaintenance": {
+    "enabled": true,
+    "automerge": true
+  },
+
   "semanticCommits": "enabled",
   "semanticCommitType": "fix",
   "semanticCommitScope": "deps",


### PR DESCRIPTION
## What changed

Enables Renovate lock-file maintenance and allows those maintenance PRs to auto-merge once the repository’s existing lint, unit-test, Checkov and Docker-build checks are green.

## Why

The workflow-trigger and concurrency improvements from the original version of this PR were superseded by #170. This PR now contains only the remaining gold-standard configuration gap.

## Validation

This is a Renovate JSON-only change and remains gated by the repository’s normal pull-request checks.