### PR TITLE
ci: avoid duplicate branch runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,13 +7,18 @@ on:
       - "release-please-**"
   push:
     branches:
-      - "*"
+      - "main"
+      - "develop"
     paths-ignore:
       - README.md
       - CHANGELOG.md
       - version.txt
       - ".github/workflows/**"
   workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   lint:

--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,10 +1,5 @@
 name: Renovate
 on:
-  push:
-    branches:
-      - "*"
-    paths:
-      - ".github/workflows/renovate.yaml"
   schedule:
     # The "*" (#42, asterisk) character has special semantics in YAML, so this
     # string has to be quoted.
@@ -23,6 +18,13 @@ on:
         description: Renovate version
         default: latest
         required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: renovate
+  cancel-in-progress: false
 
 jobs:
   renovate:


### PR DESCRIPTION
Removes duplicate CI/Renovate executions while preserving the existing gates:

- branch pushes run the build workflow only for `main` and `develop`; feature branches are validated by their pull-request run
- superseded CI runs on the same ref are cancelled
- Renovate runs on its daily schedule or manual dispatch only
- Renovate now has an explicit concurrency group and read-only default permissions

The lint, test and Docker build jobs are unchanged.