### PR TITLE
Update GoFile website token salt

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ docker-compose up -d
 | `DEFAULT_RETRIES`      | Default retry attempts                                                                          | `3`                       | `5`                            |
 | `RETRY_DELAY`          | Seconds between retry attempts                                                                  | `5`                       | `10`                           |
 | `GOFILE_PREMIUM_TOKEN` | GoFile premium account token                                                                    | `None`                    | `your-token-here`              |
-| `GOFILE_WT_SALT`       | Salt for website-token generation (update if GoFile rotates it)                                 | current known value       | `9844d94d963d30`               |
+| `GOFILE_WT_SALT`       | Salt for website-token generation (update if GoFile rotates it)                                 | current known value       | `12af056dacea0b`               |
 | `GOFILE_USER_AGENT`    | User-Agent used for API + token                                                                 | Chrome UA string          | `Mozilla/5.0 ...`              |
 | `GOFILE_LANGUAGE`      | Language used for `X-BL` + token                                                                | `en-US`                   | `en-US`                        |
 | `GOFILE_PROXY`         | HTTP/SOCKS proxy for GoFile requests (use a clean IP if `api.gofile.io` resets your connection) | `None`                    | `socks5://user:pass@host:1080` |

--- a/run.py
+++ b/run.py
@@ -103,7 +103,7 @@ GOFILE_USER_AGENT = os.environ.get(
 GOFILE_LANGUAGE = os.environ.get("GOFILE_LANGUAGE", "en-US")
 # Salt currently embedded in wt.obf.js. If GoFile rotates it and downloads start
 # failing with "error-notPremium" again, update this value (or set the env var).
-GOFILE_WT_SALT = os.environ.get("GOFILE_WT_SALT", "9844d94d963d30")
+GOFILE_WT_SALT = os.environ.get("GOFILE_WT_SALT", "12af056dacea0b")
 WT_WINDOW_SECONDS = 14400  # 4-hour rotating window used by GoFile
 
 # Query parameters GoFile's web client now sends on every /contents request.


### PR DESCRIPTION
Updates the default `GOFILE_WT_SALT` value to match the current salt embedded in `https://gofile.io/js/wt.obf.js`.

The old value returns `error-notPremium` for guest content requests.

Tested:
- `python -m pytest tests/test_basic.py -o addopts=`
- `python -m py_compile run.py`