### PR TITLE
fix(ci): stop ruff/hadolint failing the Lint workflow on every push

### DIFF
--- a/.mega-linter.yaml
+++ b/.mega-linter.yaml
@@ -15,10 +15,12 @@ PYTHON_BLACK_ARGUMENTS: "--line-length 100"
 PYTHON_FLAKE8_ARGUMENTS: "--max-line-length 100 --extend-ignore=E203,E501"
 PYTHON_ISORT_ARGUMENTS: "--profile black"
 PYTHON_PYLINT_ARGUMENTS: "--disable=C0103,C0111,R0903,W0212,import-error,no-member --max-line-length=100"
-DOCKERFILE_HADOLINT_ARGUMENTS: "--ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL3003"
+# HEALTHCHECK's CMD is intentionally shell-form (needs ${PORT} substitution
+# and the `|| exit 1` fallback, which JSON exec form can't express) — ignore
+# DL3025 alongside the other DL30xx rules already ignored here.
+DOCKERFILE_HADOLINT_ARGUMENTS: "--ignore DL3008 --ignore DL3013 --ignore DL3018 --ignore DL3003 --ignore DL3025"
 
 # Ruff configuration
-PYTHON_RUFF_ARGUMENTS: "--config=.ruff.toml"
 PYTHON_RUFF_FILTER_REGEX_EXCLUDE: '(test_.*\.py)' # Use single quotes to avoid escape issues
 PYTHON_RUFF_DISABLE_ERRORS: true # Don't fail build on ruff errors
 PYTHON_RUFF_DISABLE_ERRORS_IF_LESS_THAN: 10 # Only fail if more than 10 errors


### PR DESCRIPTION
## Summary
The standalone `Lint` workflow (MegaLinter, triggered directly on push to `main`) has failed on every single push for at least the last 30 runs. Two separate causes:

- **ruff**: `PYTHON_RUFF_ARGUMENTS: "--config=.ruff.toml"` and `PYTHON_RUFF_CONFIG_FILE: .ruff.toml` both resolve to a `--config` flag, so ruff was invoked with `--config=.ruff.toml --config /github/workspace/.ruff.toml` — ruff refuses two `--config` flags and crashes outright. MegaLinter treats a linter *crash* as a hard failure regardless of `DISABLE_ERRORS_LINTERS` (that setting only suppresses *found issues*, not a tool crash), so this alone failed the whole job. Dropped the redundant `PYTHON_RUFF_ARGUMENTS` line — `PYTHON_RUFF_CONFIG_FILE` already supplies the same config.
- **hadolint**: `DL3025` ("use JSON notation for CMD/ENTRYPOINT") flags the Dockerfile's `HEALTHCHECK`'s `CMD`, which is intentionally shell-form — it needs `${PORT}` substitution and the `|| exit 1` fallback, neither of which JSON exec form supports. Added `--ignore DL3025` alongside the other `DL30xx` rules already ignored in this file for the same reason.

Note: the PR-time `Lint and Build` workflow (`build.yaml` → `lint.yaml` via `workflow_call`) was passing, so this bug was silently only breaking the post-merge push-triggered run.

## Test plan
- [x] Read the MegaLinter log for the failing run — confirmed both root causes from the actual error output (`ruff failed: Cause: You cannot specify more than one configuration file`, and hadolint's `DL3025` warning on the HEALTHCHECK line).
- [ ] CI on this PR (both `Lint and Build` and the standalone `Lint` push-trigger, once merged) should go green — will confirm before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017anq3d4L4uQEZugiFoHgZY

---
_Generated by [Claude Code](https://claude.ai/code/session_017anq3d4L4uQEZugiFoHgZY)_